### PR TITLE
Fix problem with display text in setupViewMode_2

### DIFF
--- a/modules/game_textmessage/textmessage.otui
+++ b/modules/game_textmessage/textmessage.otui
@@ -8,7 +8,7 @@ TextMessageLabel < UILabel
 
 Panel
   anchors.fill: gameMapPanel
-  anchors.bottom: gameBottomPanel.top
+  anchors.bottom: gameMapPanel.bottom
   focusable: false
 
   Panel


### PR DESCRIPTION
Fix problem with display text messages in setupViewMode - 2 ([CTRL + .] x 2).
Status messages was display in other place (higher than player character).